### PR TITLE
Fix accessing manifest behind auth on chrome

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -11,7 +11,7 @@
 		<link rel="icon" type="image/png" sizes="192x192"  href="/img/android-icon-192x192.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="/img/favicon-32x32.png">
 		<link rel="icon" type="image/png" sizes="16x16" href="/img/favicon-16x16.png">
-		<link rel="manifest" href="/img/manifest.json">
+		<link rel="manifest" href="/img/manifest.json" crossorigin="use-credentials">
 	</head>
 
 	<body class="bg-gray-200">


### PR DESCRIPTION
chrome requires crossorigin="use-credentials" to pass cookies (and basic auth) for manifests